### PR TITLE
QT alignment type, duplicate call to hk.register, add .gitignore, update requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/Overlay.py
+++ b/Overlay.py
@@ -1273,10 +1273,8 @@ def windowCreate():
     instance = instanceWindow(windowDesignation=0)
     hk = SystemHotkey()
     hk.register(("control", "shift", "f"), callback=updateScan)
-    def initSearch(event):
-    	hideWindows(event)
-    	instance.newSearchwindow(event)
-    hk.register(("control", "shift", "h"), callback=initSearch)
+    hk.register(("control", "shift", "h"), callback=hideWindows)
+    # hk.register(("control", "shift", "h"), callback=instance.newSearchwindow
     for k, v in settingsDict.items():
         if "searchWindow" in v:
             instance.searchWindowdict[k] = searchWindow(windowDesignation=k)

--- a/Overlay.py
+++ b/Overlay.py
@@ -657,17 +657,17 @@ class infoWindow(instanceWindow):
             "efficencyPlatinum": QLabel(self),
         }
         self.labelTextdict = {
-            "relicItem": QLabel("Item:", self, Qt.AlignVCenter),
-            "relicAccuracy": QLabel("Accuracy:", self, Qt.AlignVCenter),
-            "platinumPrice": QLabel("Top plat:", self, Qt.AlignVCenter),
-            "platinumAvg": QLabel("Top 10 Avg:", self, Qt.AlignVCenter),
-            "ducatValue": QLabel("Ducats:", self, Qt.AlignVCenter),
-            "efficencyValue": QLabel("Efficency:", self, Qt.AlignVCenter),
+            "relicItem": QLabel("Item:", self, Qt.WindowFlags(Qt.AlignVCenter)),
+            "relicAccuracy": QLabel("Accuracy:", self, Qt.WindowFlags(Qt.AlignVCenter)),
+            "platinumPrice": QLabel("Top plat:", self, Qt.WindowFlags(Qt.AlignVCenter)),
+            "platinumAvg": QLabel("Top 10 Avg:", self, Qt.WindowFlags(Qt.AlignVCenter)),
+            "ducatValue": QLabel("Ducats:", self, Qt.WindowFlags(Qt.AlignVCenter)),
+            "efficencyValue": QLabel("Efficency:", self, Qt.WindowFlags(Qt.AlignVCenter)),
         }
         if settingsDict["listing"][0] == 0:
-            self.labelTextdict["platinumPlayer"] = QLabel("Top Seller:", self, Qt.AlignVCenter)
+            self.labelTextdict["platinumPlayer"] = QLabel("Top Seller:", self, Qt.WindowFlags(Qt.AlignVCenter))
         else:
-            self.labelTextdict["platinumPlayer"] = QLabel("Top Buyer:", self, Qt.AlignVCenter)
+            self.labelTextdict["platinumPlayer"] = QLabel("Top Buyer:", self, Qt.WindowFlags(Qt.AlignVCenter))
         for k in self.vBoxdict:
             self.vBoxdict[k].setSpacing(2)
         for k in self.hBoxdict:
@@ -915,7 +915,7 @@ class globalSettingwindow(instanceWindow):
         self.windowBox.addSpacerItem(self.topSpacer)
         # Saved Layouts
         self.savedLayoutsnames = []
-        self.savedLayoutsInfo = QLabel("Saved Layouts", self, Qt.AlignVCenter)
+        self.savedLayoutsInfo = QLabel("Saved Layouts", self, Qt.WindowFlags(Qt.AlignVCenter))
         self.savedLayoutsInfo.setFont(QFont("Tahoma", 8 * scaleFactor(), 3))
         self.savedLayoutsInfohBox = QHBoxLayout()
         self.savedLayoutsInfohBox.addStretch(0)
@@ -979,7 +979,7 @@ class globalSettingwindow(instanceWindow):
                 10 * scaleFactor(), 0, 10 * scaleFactor(), 10 * scaleFactor()
             )
         # Scale Slider
-        self.sliderInfo = QLabel("UI Scale", self, Qt.AlignVCenter)
+        self.sliderInfo = QLabel("UI Scale", self, Qt.WindowFlags(Qt.AlignVCenter))
         self.sliderInfo.setFont(QFont("Tahoma", 8 * scaleFactor(), 3))
         self.sliderInfohBox = QHBoxLayout()
         self.sliderInfohBox.addStretch(0)
@@ -1273,8 +1273,10 @@ def windowCreate():
     instance = instanceWindow(windowDesignation=0)
     hk = SystemHotkey()
     hk.register(("control", "shift", "f"), callback=updateScan)
-    hk.register(("control", "shift", "h"), callback=hideWindows)
-    hk.register(("control", "shift", "h"), callback=instance.newSearchwindow)
+    def initSearch(event):
+    	hideWindows(event)
+    	instance.newSearchwindow(event)
+    hk.register(("control", "shift", "h"), callback=initSearch)
     for k, v in settingsDict.items():
         if "searchWindow" in v:
             instance.searchWindowdict[k] = searchWindow(windowDesignation=k)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
-requests==2.20.0
-system_hotkey==1.0.3
-pytesseract==0.2.4
+certifi==2020.4.5.1
+chardet==3.0.4
+idna==2.7
 Pillow==7.1.1
 PySide2==5.14.2
+pytesseract==0.2.4
+pywin32==227
+requests==2.20.0
+shiboken2==5.14.2
+system-hotkey==1.0.3
+urllib3==1.24.3


### PR DESCRIPTION

I added the default .gitignore for python to keep git from trying to commit cache files, env, etc...
I'm running python Python 3.8.2.
I got the following error regarding system_hotkey:
```
Exception ignored in thread started by: <bound method CallSerializer.call_functions of <system_hotkey.util.CallSerializer object at 0x000001E6FA5F6C40>>
Traceback (most recent call last):
  File "C:\dev\programming\Python\david\Warframe-Market-Overlay\env\lib\site-packages\system_hotkey\util.py", line 37, in call_functions
    func(*args, **kwargs)
  File "C:\dev\programming\Python\david\Warframe-Market-Overlay\env\lib\site-packages\system_hotkey\system_hotkey.py", line 296, in register
    raise SystemRegisterError(msg, *hotkey)
system_hotkey.system_hotkey.SystemRegisterError: ('existing bind detected... unregister or set overwrite to True', 'control', 'shift', 'h')
```
It looks like ("control", "shift", "h") was assigned to both `hideWindows` and `instance.newSearchwindow` this seems incorrect

I also get this error regarding PySide2:
```
FIXME Subscripted generics cannot be used with class and instance checks
Traceback (most recent call last):
  File "overlay.py", line 1436, in <module>
    windowCreate()
  File "overlay.py", line 1281, in windowCreate
    instance.infoWindowdict[k] = infoWindow(windowDesignation=k)
  File "overlay.py", line 660, in __init__
    "relicItem": QLabel("Item:", self, Qt.AlignVCenter),
TypeError: 'PySide2.QtWidgets.QLabel' called with wrong argument types:
  PySide2.QtWidgets.QLabel(str, infoWindow, AlignmentFlag)
Supported signatures:
  PySide2.QtWidgets.QLabel(typing.Union[PySide2.QtWidgets.QWidget, NoneType] = None, PySide2.QtCore.Qt.WindowFlags = Default(Qt.WindowFlags))
  PySide2.QtWidgets.QLabel(str, typing.Union[PySide2.QtWidgets.QWidget, NoneType] = None, PySide2.QtCore.Qt.WindowFlags = Default(Qt.WindowFlags))
```

I fixed this by using `Qt.WindowFlags(Qt.AlignVCenter)` instead of using `Qt.AlignVCenter` directly

With these fixed I was able to start the overlay. After pressing control shift h the windows disappeared, however after pressing control shift h again they did not reappear. I'm not sure why though, the hideWindows function was clearly still being called. 

Also, the application does not stop with Control-C or Control-Break. I didn't look into this.